### PR TITLE
Estimating effort in pomodoro units using `C-c C-x e`.

### DIFF
--- a/org-pomodoro.el
+++ b/org-pomodoro.el
@@ -650,6 +650,28 @@ kill the current timer, this may be a break or a running pomodoro."
           (call-interactively 'org-clock-in))))
     (org-pomodoro-start :pomodoro))))
 
+;;
+;; Tip from: https://emacs.stackexchange.com/a/62338/17985
+;;
+(defun ndk/org-set-effort-in-pomodoros (&optional n)
+  "This `fn` facilitate to define efforts in tasks in pomodoros units.
+
+You can use interactively by typing `C-c C-x e` or by sending parameter as `M-3 C-c C-x e`."
+  (interactive "P")
+  (setq n (or n (string-to-number (read-from-minibuffer "How many pomodoros? " nil nil nil nil "1" nil))))
+  (let* ((mins-per-pomodoro (if org-pomodoro-length
+                                org-pomodoro-length
+                              25)))
+    (org-set-effort nil (org-duration-from-minutes (* n mins-per-pomodoro)))))
+
+;;
+;; Redefine the key binding `C-c C-x e' which was originally bound to `org-set-effort'
+;;  to the pomodoro function
+;;
+;; See also `ndk/org-set-effort-in-pomodoros` fn for more info.
+;;
+(define-key org-mode-map (kbd "C-c C-x e") #'ndk/org-set-effort-in-pomodoros)
+
 (provide 'org-pomodoro)
 
 ;;; org-pomodoro.el ends here


### PR DESCRIPTION
Emacs change its behavior since this commit:

ttps://code.orgmode.org/bzg/org-mode/commit/d6369e9ac69ce367e862a9678bb46cdc60b77f1f

and define properties like:

isn't so useful anymore. This commit fix this behavior by changing by default the keybind `C-c C-x e` to the new fn that asks how much pomodoros you will do as effort in a task.

More discussion here:

https://emacs.stackexchange.com/a/62338/17985