### PR TITLE
Add default arguments for shell commands feature

### DIFF
--- a/org-pomodoro.el
+++ b/org-pomodoro.el
@@ -98,6 +98,11 @@ finishes the pomodoro and enters the break period."
   :group 'org-pomodoro
   :type 'string)
 
+(defcustom org-pomodoro-default-args nil
+  "Default arguments appended to all other args."
+  :group 'org-pomodoro
+  :type 'string)
+
 ;;; POMODORO START SOUND
 (defcustom org-pomodoro-start-sound-p nil
   "Determines whether to play a sound when a pomodoro started.
@@ -421,7 +426,7 @@ or :break when starting a break.")
 	    "org-pomodoro-audio-player" nil
 	    (mapconcat 'identity
 		       `(,org-pomodoro-audio-player
-			 ,@(delq nil (list args (shell-quote-argument (expand-file-name sound)))))
+			 ,@(delq nil (list org-pomodoro-default-args args (shell-quote-argument (expand-file-name sound)))))
 		       " "))))))
 
 (defun org-pomodoro-maybe-play-sound (type)


### PR DESCRIPTION
Both default audio players(`aplay` and `afplay`) don't have a configuration file.
Generally minimal audio players such as ffplay, mpg123  don't have a configuration file either. 
So if a user wants a default option they need to compile their program or set 7 sound options with the same string.

Default arguments are useful for volume and no window settings. For example, I use:
```lisp
(setq org-pomodoro-audio-player "/usr/bin/ffplay")
(setq org-pomodoro-default-args "-volume 70 -autoexit -nodisp")))
```
By default `aplay` plays sound at the current audio level. So one can get an ear blast pretty easily.