### PR TITLE
Fix package-lint errors, enable lexical-binding

### DIFF
--- a/org-pomodoro.el
+++ b/org-pomodoro.el
@@ -1,10 +1,10 @@
-;;; org-pomodoro.el --- Pomodoro implementation for org-mode.
+;;; org-pomodoro.el --- Pomodoro implementation for org-mode  -*- lexical-binding: t; -*-
 
 ;; Author: Arthur Leonard Andersen <leoc.git@gmail.com>, Marcin Koziej <marcin at lolownia dot org>
 ;; URL: https://github.com/lolownia/org-pomodoro
 ;; Created: May 10, 2013
 ;; Version: 2.1.0
-;; Package-Requires: ((alert "0.5.10") (cl-lib "0.5"))
+;; Package-Requires: ((alert "0.5.10") (cl-lib "0.5") (emacs "24.1"))
 
 ;; This file is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Check by running `M-x package-lint-current-buffer` in org-pomodoro.el.